### PR TITLE
Update Domain.pm

### DIFF
--- a/lib/Mail/STS/Domain.pm
+++ b/lib/Mail/STS/Domain.pm
@@ -98,7 +98,7 @@ my $RECORDS = {
   },
   'tlsrpt' => {
     type => 'TXT',
-    name => sub { '_smtp._tcp.'.shift },
+    name => sub { '_smtp._tls.'.shift },
   },
 };
 


### PR DESCRIPTION
Modified the TLSRPT to point to _smtp._tls.(Domain.name) rather than _smtp._tcp.(Domain.Name) per RFC 8460.