### PR TITLE
following CNAMEs

### DIFF
--- a/lib/Mail/STS/SSKV.pm
+++ b/lib/Mail/STS/SSKV.pm
@@ -9,7 +9,18 @@ requires 'fields';
 
 sub new_from_string {
   my ($class, $string) = @_;
-  my %kv = map { split(/=/,$_,2) } split(/\s*;\s*/, $string);
+  my @assignments = split(/\s*;\s*/, $string);
+  my %kv;
+  foreach my $assignment (@assignments) {
+    if ($assignment !~ /=/) {
+      next;
+    }
+    my ($key, $value) = split(/=/, $assignment, 2);
+    $kv{$key} = $value;
+  }
+  if (! keys(%kv)) {
+    return;
+  }
   return $class->new(%kv);
 }
 

--- a/t/domain.t
+++ b/t/domain.t
@@ -10,7 +10,7 @@ unless($ENV{'INTERNET_TESTING'}) {
   plan skip_all => 'No remote tests. (to enable set INTERNET_TESTING=1)';
 }
 
-plan tests => 24;
+plan tests => 26;
 
 use_ok('Mail::STS');
 use_ok('Mail::STS::Domain');
@@ -53,3 +53,8 @@ ok($p->is_tlsa_secure, 'TLSA record is secure');
 ok(!defined $p->tlsrpt, 'has no TLSRPT record');
 ok(!defined $p->sts, 'has no STS record');
 
+# CNAME follow domain
+$p = $sts->domain('mail-sts-test.errror.org');
+isa_ok($p->sts, 'Mail::STS::STSRecord');
+$p = $sts->domain('mail-sts-fail.errror.org');
+ok(!defined $p->sts, 'has no STS record');

--- a/t/policy.t
+++ b/t/policy.t
@@ -10,7 +10,7 @@ unless($ENV{'INTERNET_TESTING'}) {
   plan skip_all => 'No remote tests. (to enable set INTERNET_TESTING=1)';
 }
 
-plan tests => 23;
+plan tests => 22;
 
 use_ok('Mail::STS::Policy');
 


### PR DESCRIPTION
Hi Markus,

this patch makes Mail::STS follow CNAMEs when doing lookups for the different DNS records used. To avoid infinite looks only CNAME chains up to a recursion level of 20 are considered.

The patch also includes 2 small fixes:
- avoid undef warnings when parsing TXT records
- fixed number of tests in `policy.t`

I would really appreciate a successful merge followed by a new release.

Thanks for providing this library!